### PR TITLE
Refactor/jokenpo components encapsulation and computation

### DIFF
--- a/laravel-version/app/Livewire/JoKenPo.php
+++ b/laravel-version/app/Livewire/JoKenPo.php
@@ -7,42 +7,45 @@ use Livewire\Component;
 
 class JoKenPo extends Component
 {
-    public $playerHand;
-    public $iaHand;
-    public $resultText;
     public $hands;
-    public $initialPlayerLife = 5;
-    public $initialIaLife = 5;
-    public $playerLife;
-    public $iaLife;
+    public $player;
+    public $ia;
+    public $resultText;
 
     #[Computed]
     public function playerLifeTaken() {
-        return $this->initialPlayerLife - $this->playerLife;
+        return $this->player['initialLife'] - $this->player['currentLife'];
     }
 
     #[Computed]
     public function iaLifeTaken() {
-        return $this->initialIaLife - $this->iaLife;
+        return $this->ia['initialLife'] - $this->ia['currentLife'];
     }
 
     public function mount() {
         $this->hands = [
-            'rock' => asset('storage/rock.png'),
-            'paper' => asset('storage/paper.png'),
-            'scissors' => asset('storage/scissors.png'),
+            'rock' => asset('storage/hands/rock.png'),
+            'paper' => asset('storage/hands/paper.png'),
+            'scissors' => asset('storage/hands/scissors.png'),
         ];
-        $this->initialPlayerLife = 5;
-        $this->initialIaLife = 5;
-        $this->playerLife = $this->initialPlayerLife;
-        $this->iaLife = $this->initialIaLife;
+        $this->player = [
+            'hand' => null,
+            'initialLife' => 5,
+            'currentLife' => 5,
+        ];
+        $this->ia = [
+            'hand' => null,
+            'initialLife' => 5,
+            'currentLife' => 5,
+        ];
+        $this->resultText = '';
     }
 
     public function play($playerChoice)
     {
-        $this->playerHand = $this->hands[$playerChoice];
+        $this->player['hand'] = $this->hands[$playerChoice];
         $iaChoice = array_rand($this->hands);
-        $this->iaHand = $this->hands[$iaChoice];
+        $this->ia['hand'] = $this->hands[$iaChoice];
 
         if ($playerChoice === $iaChoice) {
             $this->resultText = 'Draw!';
@@ -51,43 +54,41 @@ class JoKenPo extends Component
                 case 'rock':
                     if ($iaChoice === 'scissors') {
                         $this->resultText = 'Player won!';
-                        $this->removeLife($this->iaHand);
+                        $this->removeLife($this->ia);
                         return;
                     }
                     $this->resultText = 'IA won!';
-                    $this->removeLife($this->playerHand);
-                break;
+                    $this->removeLife($this->player);
+                    break;
                 case 'paper':
                     if ($iaChoice === 'rock') {
                         $this->resultText = 'Player won!';
-                        $this->removeLife($this->iaHand);
+                        $this->removeLife($this->ia);
                         return;
                     }
                     $this->resultText = 'IA won!';
-                    $this->removeLife($this->playerHand);
-                break;
+                    $this->removeLife($this->player);
+                    break;
                 case 'scissors':
                     if ($iaChoice === 'paper') {
                         $this->resultText = 'Player won!';
-                        $this->removeLife($this->iaHand);
+                        $this->removeLife($this->ia);
                         return;
                     }
                     $this->resultText = 'IA won!';
-                    $this->removeLife($this->playerHand);
-                break;
+                    $this->removeLife($this->player);
+                    break;
             }
         }
     }
 
-    public function removeLife($hand) {
-        $hand === $this->playerHand
-        ? ($this->playerLife -= 1)
-        : ($this->iaLife -= 1);
+    public function removeLife(&$entity) {
+        $entity['currentLife'] -= 1;
     }
 
     public function retry() {
-        $this->playerLife = $this->initialPlayerLife;
-        $this->iaLife = $this->initialIaLife;
+        $this->player['currentLife'] = $this->player['initialLife'];
+        $this->ia['currentLife'] = $this->ia['initialLife'];
         $this->resultText = '';
     }
 

--- a/laravel-version/app/Livewire/JoKenPoXLuckMode.php
+++ b/laravel-version/app/Livewire/JoKenPoXLuckMode.php
@@ -2,142 +2,167 @@
 
 namespace App\Livewire;
 
+use Illuminate\Support\Facades\Log;
 use Livewire\Attributes\Computed;
 use Livewire\Component;
 
 class JoKenPoXLuckMode extends Component
 {
-    public $playerHand;
-    public $iaHand;
-    public $resultText;
     public $hands;
-    public $initialPlayerLife;
-    public $initialIaLife;
-    public $playerLife;
-    public $iaLife;
-    public $winnerFirstRound;
-    public $rollDiceTime;
-    public $diceRolledByPlayer;
-    public $diceRolledByIa;
-    public $diceBeforeRolling;
-    public $continueTime;
+    public $dices;
+    public $player;
+    public $ia;
+    public $resultText;
+    public $isContinueTime;
+    public $firstRoundWinner;
 
     #[Computed]
     public function playerLifeTaken() {
-        return $this->initialPlayerLife - $this->playerLife;
+        if (!$this->player['life']) return 0;
+
+        return $this->player['life']['initial'] - $this->player['life']['current'];
     }
 
     #[Computed]
     public function iaLifeTaken() {
-        return $this->initialIaLife - $this->iaLife;
+        if (!$this->ia['life']) return 0;
+
+        return $this->ia['life']['initial'] - $this->ia['life']['current'];
+    }
+
+    #[Computed]
+    public function showHands() {
+        return $this->player['hand'] && $this->ia['hand'];
+    }
+
+    #[Computed]
+    public function showDices() {
+        return $this->firstRoundWinner;
     }
 
     public function mount() {
         $this->hands = [
-            'rock' => asset('storage/rock.png'),
-            'paper' => asset('storage/paper.png'),
-            'scissors' => asset('storage/scissors.png'),
+            'rock' => asset('storage/hands/rock.png'),
+            'paper' => asset('storage/hands/paper.png'),
+            'scissors' => asset('storage/hands/scissors.png'),
         ];
-        $this->initialPlayerLife = 5;
-        $this->initialIaLife = 5;
-        $this->playerLife = $this->initialPlayerLife;
-        $this->iaLife = $this->initialIaLife;
-        $this->diceBeforeRolling = asset('storage/dice-first-frame.png');
+        $this->dices = [
+            'initial' => asset('storage/dices/initial.png'),
+            '1' => asset('storage/dices/1.gif'),
+            '2' => asset('storage/dices/2.gif'),
+            '3' => asset('storage/dices/3.gif'),
+            '4' => asset('storage/dices/4.gif'),
+            '5' => asset('storage/dices/5.gif'),
+            '6' => asset('storage/dices/6.gif'),
+        ];
+        $this->player = [
+            'hand' => null,
+            'life' => [
+                'initial' => 5,
+                'current' => 5,
+            ],
+            'dice' => null,
+        ];
+        $this->ia = [
+            'hand' => null,
+            'life' => [
+                'initial' => 5,
+                'current' => 5,
+            ],
+            'dice' => null,
+        ];
+        $this->isContinueTime = false;
     }
 
     public function playFirstRound($playerChoice)
     {
-        $this->playerHand = $this->hands[$playerChoice];
+        $this->player['hand'] = $this->hands[$playerChoice];
         $iaChoice = array_rand($this->hands);
-        $this->iaHand = $this->hands[$iaChoice];
+        $this->ia['hand'] = $this->hands[$iaChoice];
 
         if ($playerChoice === $iaChoice) {
             $this->resultText = 'Draw!';
         } else {
-            $this->rollDiceTime = true;
-
             switch ($playerChoice) {
                 case 'rock':
                     if ($iaChoice === 'scissors') {
                         $this->resultText = 'Player won first round';
-                        $this->winnerFirstRound = $this->playerHand;
-                        return;
+                        $this->firstRoundWinner = $this->player['hand'];
+                    } else {
+                        $this->resultText = 'IA won first round';
+                        $this->firstRoundWinner = $this->ia['hand'];
                     }
-                    $this->resultText = 'IA won first round';
-                    $this->winnerFirstRound = $this->iaHand;
-                break;
+                    break;
                 case 'paper':
                     if ($iaChoice === 'rock') {
                         $this->resultText = 'Player won first round';
-                        $this->winnerFirstRound = $this->playerHand;
-                        return;
+                        $this->firstRoundWinner = $this->player['hand'];
+                    } else {
+                        $this->resultText = 'IA won first round';
+                        $this->firstRoundWinner = $this->ia['hand'];
                     }
-                    $this->resultText = 'IA won first round';
-                    $this->winnerFirstRound = $this->iaHand;
-                break;
+                    break;
                 case 'scissors':
                     if ($iaChoice === 'paper') {
                         $this->resultText = 'Player won first round';
-                        $this->winnerFirstRound = $this->playerHand;
-                        return;
+                        $this->firstRoundWinner = $this->player['hand'];
+                    } else {
+                        $this->resultText = 'IA won first round';
+                        $this->firstRoundWinner = $this->ia['hand'];
                     }
-                    $this->resultText = 'IA won first round';
-                    $this->winnerFirstRound = $this->iaHand;
-                break;
             }
         }
     }
 
     public function playSecondRound() {
         $playerDiceNumber = random_int(1, 6);
-        $iaDiceNumber =   random_int(1, 6);
+        $iaDiceNumber = random_int(1, 6);
 
-        $this->diceRolledByPlayer = asset('storage/dice-' . $playerDiceNumber . '.gif');
-        $this->diceRolledByIa = asset('storage/dice-' . $iaDiceNumber . '.gif');
+        $this->player['dice'] = $this->dices[$playerDiceNumber];
+        $this->ia['dice'] = $this->dices[$iaDiceNumber];
 
-        if ($this->winnerFirstRound === $this->playerHand) {
+        if ($this->firstRoundWinner === $this->player['hand']) {
             if ($playerDiceNumber > $iaDiceNumber) {
                 $this->resultText = 'Player attacked and damaged IA';
-                $this->removeLife($this->iaHand);
+                $this->removeLife($this->ia['hand']);
             } else if ($playerDiceNumber < $iaDiceNumber) {
                 $this->resultText = 'IA defended himself against player attack';
             } else {
                 $this->resultText = 'Draw!';
                 return;
             }
-        } else if ($this->winnerFirstRound === $this->iaHand) {
+        } else if ($this->firstRoundWinner === $this->ia['hand']) {
             if ($playerDiceNumber > $iaDiceNumber) {
                 $this->resultText = 'Player defended himself against IA attack';
             } else if ($playerDiceNumber < $iaDiceNumber) {
                 $this->resultText = 'IA attacked and damaged player';
-                $this->removeLife($this->playerHand);
+                $this->removeLife($this->player['hand']);
             } else {
                 $this->resultText = 'Draw!';
                 return;
             }
         }
 
-        $this->continueTime = true;
+        $this->isContinueTime = true;
     }
 
     public function continueGame() {
-        $this->rollDiceTime = false;
-        $this->continueTime = false;
-        $this->diceRolledByPlayer = null;
-        $this->diceRolledByIa = null;
-        $this->winnerFirstRound = null;
+        $this->isContinueTime = false;
+        $this->player['dice'] = null;
+        $this->ia['dice'] = null;
+        $this->firstRoundWinner = null;
         $this->resultText = '';
     }
 
     public function removeLife($hand) {
-        $hand === $this->playerHand
-        ? ($this->playerLife -= 1)
-        : ($this->iaLife -= 1);
+        $hand === $this->player['hand']
+        ? ($this->player['life']['current'] -= 1)
+        : ($this->ia['life']['current'] -= 1);
     }
 
     public function retry() {
-        $this->playerLife = $this->initialPlayerLife;
-        $this->iaLife = $this->initialIaLife;
+        $this->player['life']['current'] = $this->player['life']['initial'];
+        $this->ia['life']['current'] = $this->ia['life']['initial'];
         $this->resultText = '';
     }
 

--- a/laravel-version/resources/views/livewire/jo-ken-po-x-luck-mode.blade.php
+++ b/laravel-version/resources/views/livewire/jo-ken-po-x-luck-mode.blade.php
@@ -8,7 +8,7 @@
                     Player
                 </p>
                 <div class="flex gap-2">
-                    @for($i = 0; $i < $playerLife; $i++)
+                    @for($i = 0; $i < $player['life']['current']; $i++)
                     <i class="text-red-500 fas fa-heart float" wire:loading.class="fade-out"></i>
                     @endfor
                     @for($i = 0; $i < $this->playerLifeTaken; $i++)
@@ -17,8 +17,8 @@
                 </div>
             </div>
             <div class="relative flex items-center justify-center transform rotate-90 player-hand-wrapper w-72 h-72">
-                @if($playerHand) <img src="{{ $playerHand }}" wire:loading.class="fade-out" class="w-3/4 player-hand hand h-3/4"/> @endif
-                @if($rollDiceTime) <img src="{{ $diceRolledByPlayer ?: $diceBeforeRolling }}" class="absolute w-28 h-2w-28"/> @endif
+                @if($this->showHands) <img src="{{ $player['hand'] }}" wire:loading.class="fade-out" class="w-3/4 player-hand hand h-3/4"/> @endif
+                @if($this->showDices) <img src="{{ $player['dice'] ?: $dices['initial'] }}" class="absolute w-28 h-28 top-72"/> @endif
             </div>
         </div>
 
@@ -28,7 +28,7 @@
                     IA
                 </p>
                 <div class="flex gap-2">
-                    @for($i = 0; $i < $iaLife; $i++)
+                    @for($i = 0; $i < $ia['life']['current']; $i++)
                     <i class="text-red-500 fas fa-heart float" wire:loading.class="fade-out"></i>
                     @endfor
                     @for($i = 0; $i < $this->iaLifeTaken; $i++)
@@ -37,16 +37,16 @@
                 </div>
             </div>
             <div class="relative flex items-center justify-center transform -rotate-90 ia-hand-wrapper w-72 h-72">
-                @if($iaHand) <img src="{{ $iaHand }}" wire:loading.class="fade-out" class="w-3/4 ia-hand hand h-3/4"/> @endif
-                @if($rollDiceTime) <img src="{{ $diceRolledByIa ?: $diceBeforeRolling }}" class="absolute w-28 h-2w-28"/> @endif
+                @if($this->showHands) <img src="{{ $ia['hand'] }}" wire:loading.class="fade-out" class="w-3/4 ia-hand hand h-3/4"/> @endif
+                @if($this->showDices) <img src="{{ $ia['dice'] ?: $dices['initial'] }}" class="absolute w-28 h-28 top-72"/> @endif
             </div>
         </div>
     </div>
 
     <div class="flex w-full max-w-2xl gap-10 m-auto mt-8 jokenpo-btns-wrapper">
-        <button type="button" wire:click="playFirstRound('rock')" @if($playerLife < 1 || $iaLife < 1 || $rollDiceTime) disabled @endif class="w-full text-black bg-gray-100 rounded shadow rock-btn hover:bg-gray-200">rock</button>
-        <button type="button" wire:click="playFirstRound('paper')" @if($playerLife < 1 || $iaLife < 1 || $rollDiceTime) disabled @endif class="w-full text-black bg-gray-100 rounded shadow paper-btn hover:bg-gray-200">paper</button>
-        <button type="button" wire:click="playFirstRound('scissors')" @if($playerLife < 1 || $iaLife < 1 || $rollDiceTime) disabled @endif class="w-full text-black bg-gray-100 rounded shadow scissors-btn hover:bg-gray-200">scissors</button>
+        <button type="button" wire:click="playFirstRound('rock')" @if($player['life']['current'] < 1 || $ia['life']['current'] < 1 || $this->showDices) disabled @endif class="w-full text-black bg-gray-100 rounded shadow rock-btn hover:bg-gray-200">rock</button>
+        <button type="button" wire:click="playFirstRound('paper')" @if($player['life']['current'] < 1 || $ia['life']['current'] < 1 || $this->showDices) disabled @endif class="w-full text-black bg-gray-100 rounded shadow paper-btn hover:bg-gray-200">paper</button>
+        <button type="button" wire:click="playFirstRound('scissors')" @if($player['life']['current'] < 1 || $ia['life']['current'] < 1 || $this->showDices) disabled @endif class="w-full text-black bg-gray-100 rounded shadow scissors-btn hover:bg-gray-200">scissors</button>
     </div>
 
     <div class="flex flex-col items-center mt-8">
@@ -61,32 +61,32 @@
                 ])
                 wire:loading.class="fade-out"
             >
-                @if($playerLife > 1 && $iaLife > 1)
+                @if($player['life']['current'] > 1 && $ia['life']['current'] > 1)
                     {{ $resultText }}
                 @else
-                    @if($winnerFirstRound && $winnerFirstRound === $playerHand && !$continueTime)
+                    @if($winnerFirstRound && $winnerFirstRound === $player['hand'] && !($pausedTime === 'continue'))
                         <p class='font-sans text-lg text-white'>Roll the dice to hit the AI!</p>
-                    @elseif($winnerFirstRound && $winnerFirstRound === $iaHand && !$continueTime)
+                    @elseif($winnerFirstRound && $winnerFirstRound === $ia['hand'] && !($pausedTime === 'continue'))
                         <p class='font-sans text-lg text-white'>Roll the dice to defend yourself against AI!</p>
                     @else
-                        {{$playerLife < 1 && 'IA won the game.'}}
-                        {{$iaLife < 1 && 'Player won the game.'}}
+                        {{$player['life']['current'] < 1 && 'IA won the game.'}}
+                        {{$ia['life']['current'] < 1 && 'Player won the game.'}}
                     @endif
                 @endif
 
             </p>
         </div>
-        @if($playerLife < 1 || $iaLife < 1)
+        @if($player['life']['current'] < 1 || $ia['life']['current'] < 1)
             <button type="button" wire:click="retry" class="px-4 py-3 mt-5 text-3xl font-medium text-gray-900 bg-white border border-gray-200 rounded-full me-2 focus:outline-none hover:bg-gray-100 hover:text-blue-700 focus:z-10 focus:ring-4 focus:ring-gray-100 dark:focus:ring-gray-700 dark:bg-gray-800 dark:text-gray-400 dark:border-gray-600 dark:hover:text-white dark:hover:bg-gray-700">
                 <i class="fas fa-redo"></i>
             </button>
         @endif
-        @if($rollDiceTime && !$continueTime)
+        @if($this->showDices && !$isContinueTime)
             <button type="button" wire:click="playSecondRound()" class="px-4 py-3 mt-5 text-2xl font-medium text-gray-900 bg-white border border-gray-200 rounded-full me-2 focus:outline-none hover:bg-gray-100 hover:text-blue-700 focus:z-10 focus:ring-4 focus:ring-gray-100 dark:focus:ring-gray-700 dark:bg-gray-800 dark:text-gray-400 dark:border-gray-600 dark:hover:text-white dark:hover:bg-gray-700">
                 <i class="fas fa-dice"></i>
             </button>
         @endif
-        @if($continueTime)
+        @if($isContinueTime)
             <button type="button" wire:click="continueGame()" class="px-4 py-3 mt-5 text-2xl font-medium text-gray-900 bg-white border border-gray-200 rounded-full me-2 focus:outline-none hover:bg-gray-100 hover:text-blue-700 focus:z-10 focus:ring-4 focus:ring-gray-100 dark:focus:ring-gray-700 dark:bg-gray-800 dark:text-gray-400 dark:border-gray-600 dark:hover:text-white dark:hover:bg-gray-700">
                 <i class="fas fa-arrow-right"></i> Continue
             </button>

--- a/laravel-version/resources/views/livewire/jo-ken-po.blade.php
+++ b/laravel-version/resources/views/livewire/jo-ken-po.blade.php
@@ -6,7 +6,7 @@
                     Player
                 </p>
                 <div class="flex gap-2">
-                    @for($i = 0; $i < $playerLife; $i++)
+                    @for($i = 0; $i < $player['currentLife']; $i++)
                     <i class="text-red-500 fas fa-heart float" wire:loading.class="fade-out"></i>
                     @endfor
                     @for($i = 0; $i < $this->playerLifeTaken; $i++)
@@ -15,7 +15,7 @@
                 </div>
             </div>
             <div class="flex items-center justify-center transform rotate-90 player-hand-wrapper w-72 h-72">
-                @if($playerHand) <img src="{{ $playerHand }}" wire:loading.class="fade-out" class="w-3/4 player-hand hand h-3/4"/> @endif
+                @if($player['hand']) <img src="{{ $player['hand'] }}" wire:loading.class="fade-out" class="w-3/4 player-hand hand h-3/4"/> @endif
             </div>
         </div>
 
@@ -25,7 +25,7 @@
                     IA
                 </p>
                 <div class="flex gap-2">
-                    @for($i = 0; $i < $iaLife; $i++)
+                    @for($i = 0; $i < $ia['currentLife']; $i++)
                     <i class="text-red-500 fas fa-heart float" wire:loading.class="fade-out"></i>
                     @endfor
                     @for($i = 0; $i < $this->iaLifeTaken; $i++)
@@ -34,15 +34,15 @@
                 </div>
             </div>
             <div class="flex items-center justify-center transform -rotate-90 ia-hand-wrapper w-72 h-72">
-                @if($iaHand) <img src="{{ $iaHand }}" wire:loading.class="fade-out" class="w-3/4 ia-hand hand h-3/4"/> @endif
+                @if($ia['hand']) <img src="{{ $ia['hand'] }}" wire:loading.class="fade-out" class="w-3/4 ia-hand hand h-3/4"/> @endif
             </div>
         </div>
     </div>
 
     <div class="flex w-full max-w-2xl gap-10 m-auto mt-8 jokenpo-btns-wrapper">
-        <button type="button" wire:click="play('rock')" @if($playerLife < 1 || $iaLife < 1) disabled @endif class="w-full text-black bg-gray-100 rounded shadow rock-btn hover:bg-gray-200">rock</button>
-        <button type="button" wire:click="play('paper')" @if($playerLife < 1 || $iaLife < 1) disabled @endif class="w-full text-black bg-gray-100 rounded shadow paper-btn hover:bg-gray-200">paper</button>
-        <button type="button" wire:click="play('scissors')" @if($playerLife < 1 || $iaLife < 1) disabled @endif class="w-full text-black bg-gray-100 rounded shadow scissors-btn hover:bg-gray-200">scissors</button>
+        <button type="button" wire:click="play('rock')" @if($player['currentLife'] < 1 || $ia['currentLife'] < 1) disabled @endif class="w-full text-black bg-gray-100 rounded shadow rock-btn hover:bg-gray-200">rock</button>
+        <button type="button" wire:click="play('paper')" @if($player['currentLife'] < 1 || $ia['currentLife'] < 1) disabled @endif class="w-full text-black bg-gray-100 rounded shadow paper-btn hover:bg-gray-200">paper</button>
+        <button type="button" wire:click="play('scissors')" @if($player['currentLife'] < 1 || $ia['currentLife'] < 1) disabled @endif class="w-full text-black bg-gray-100 rounded shadow scissors-btn hover:bg-gray-200">scissors</button>
     </div>
 
     <div class="flex flex-col items-center mt-8">
@@ -60,11 +60,10 @@
                 {{ $resultText }}
             </p>
         </div>
-        @if($playerLife < 1 || $iaLife < 1)
+        @if($player['currentLife'] < 1 || $ia['currentLife'] < 1)
             <button type="button" wire:click="retry" class="px-4 py-3 mt-5 text-3xl font-medium text-gray-900 bg-white border border-gray-200 rounded-full me-2 focus:outline-none hover:bg-gray-100 hover:text-blue-700 focus:z-10 focus:ring-4 focus:ring-gray-100 dark:focus:ring-gray-700 dark:bg-gray-800 dark:text-gray-400 dark:border-gray-600 dark:hover:text-white dark:hover:bg-gray-700">
                 <i class="fas fa-redo"></i>
             </button>
         @endif
     </div>
-
 </div>


### PR DESCRIPTION
## Refactoring of JoKenPo Components

### Description
 The props of the components related to each other have been encapsulated and, when possible, computated.
### Notes
- computation example: the "roll dice" button is only showed when `isContinueTime` is false and `showDices` is true, being the value of the last one calculated based wheter the first round has a winner or don't - it has after the first round and it doesn't after next set starts: the only moment the dices have to appear.
- encapsulation example:
  - public $playerHand;
    public $iaHand;
    public $initialPlayerLife;
    public $initialIaLife;
    public $playerLife;
    public $iaLife;
    public $diceRolledByPlayer;
    public $diceRolledByIa;
    
   - public $player = [ hand, currentLife, dice ];
     public $ia= [ hand, currentLife, dice ];